### PR TITLE
user側taskのビューの骨組み

### DIFF
--- a/app/controllers/public/homes_controller.rb
+++ b/app/controllers/public/homes_controller.rb
@@ -1,2 +1,8 @@
 class Public::HomesController < ApplicationController
+  
+  def top
+  end
+  
+  def about
+  end
 end

--- a/app/controllers/public/task_progresses_controller.rb
+++ b/app/controllers/public/task_progresses_controller.rb
@@ -1,2 +1,14 @@
 class Public::TaskProgressesController < ApplicationController
+  # このコントローラー必要か？
+  def update
+    @task = Task.find(params[:id])
+    @task.update(task_params)
+    redirect_to request.referer
+  end
+  
+  private
+  
+  def task_params
+    params.require(:task).permit(:title, :detail, :priority_status, :due, :progress_status)
+  end
 end

--- a/app/controllers/public/tasks_controller.rb
+++ b/app/controllers/public/tasks_controller.rb
@@ -1,2 +1,44 @@
 class Public::TasksController < ApplicationController
+  before_action :set_task, only: [:show, :edit, :update, :destroy]
+  
+  def new
+    @task = Task.new
+  end
+  
+  def index
+    @tasks = current_user.tasks
+  end
+  
+  def show
+  end
+  
+  def edit
+  end
+  
+  def create
+    @task = Task.new(task_params)
+    @task.user_id = current_user.id
+    @task.save
+    redirect_to tasks_path
+  end
+  
+  def update
+    @task.update(task_params)
+    redirect_to request.referer
+  end
+  
+  def destroy
+    @task.destroy
+    redirect_to request.referer
+  end
+  
+  private
+  
+  def task_params
+    params.require(:task).permit(:title, :detail, :priority_status, :due, :progress_status)
+  end
+  
+  def set_task
+    @task = Task.find(params[:id])
+  end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,7 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+  
+  def created_at_jst
+    created_at.in_time_zone('Tokyo').strftime("%Y年%m月%d日 %H:%M")
+  end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,6 +1,10 @@
 class Task < ApplicationRecord
   belongs_to :user
   
-  enum priority_status: { high: 0, middle: 1, low: 2 }
-  enum progress_status: { new_task: 0, in_progress: 1, completed: 2, pending: 3 }
+  enum priority_status: { 高: 0, 中: 1, 低: 2 }
+  enum progress_status: { 未着手: 0, 処理中: 1, 完了: 2, 保留: 3 }
+  
+  def due_jst
+    due.in_time_zone('Tokyo').strftime("%Y年%m月%d日 %H:%M")
+  end
 end

--- a/app/views/public/homes/about.html.erb
+++ b/app/views/public/homes/about.html.erb
@@ -1,0 +1,1 @@
+<h1>public/homes/about</h1>

--- a/app/views/public/tasks/edit.html.erb
+++ b/app/views/public/tasks/edit.html.erb
@@ -1,0 +1,30 @@
+<h1>リスト編集画面</h1>
+
+<table>
+  <%= form_with model: @task, url: "/tasks/#{@task.id}", method: :patch, local:true do |f| %>
+    <tr>
+      <th><%= f.label :due, '期日' %></th>
+      <td><%= f.datetime_select :due, use_month_numbers: true, class: "form-control" %></td>
+    </tr>
+    <tr>
+      <th><%= f.label :title, 'タイトル' %></th>
+      <td><%= f.text_field :title %></td>
+    </tr>
+    <tr>
+      <th><%= f.label :detail, '詳細' %></th>
+      <td><%= f.text_area :detail %></td>
+    </tr>
+    <tr>
+      <th><%= f.label :priority_status, '優先度' %></th>
+      <td><%= f.select :priority_status, Task.priority_statuses.keys, {} %></td>
+    </tr>
+    <tr>
+      <th><%= f.label :progress_status, '進捗度' %></th>
+      <td><%= f.select :progress_status, Task.progress_statuses.keys, {} %></td>
+    </tr>
+    <tr>
+      <td><%= f.submit '更新' %></td>
+      <td><%= link_to '削除する', task_path(@task.id), method: :delete, "data-confirm" => "#{@task.title}をリストから削除しますか？" %></td>
+    </tr>
+  <% end %>
+</table>

--- a/app/views/public/tasks/index.html.erb
+++ b/app/views/public/tasks/index.html.erb
@@ -1,0 +1,31 @@
+<h1>リスト一覧画面</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>タイトル</th>
+      <th>作成日</th>
+      <th>期日</th>
+      <th>優先度</th>
+      <th>進捗度</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @tasks.each do |task| %>
+      <tr>
+        <td><%= link_to task.title, task_path(task.id) %></td>
+        <td><%= task.created_at_jst %></td>
+        <td><%= task.due_jst %></td>
+        <td><%= task.priority_status %></td>
+        <td>
+          <%= form_with model: task, url: "/tasks/#{task.id}", method: :patch, local:true do |f| %>
+            <%= f.select :progress_status, Task.progress_statuses.keys, {} %>
+            <%= f.submit '更新' %>
+          <% end %>
+        </td>
+        <td><%= link_to '編集する', edit_task_path(task.id) %></td>
+        <td><%= link_to '削除する', task_path(task.id), method: :delete, "data-confirm" => "#{task.title}をリストから削除しますか？" %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/public/tasks/new.html.erb
+++ b/app/views/public/tasks/new.html.erb
@@ -1,0 +1,28 @@
+<h1>リスト作成画面</h1>
+
+<%= form_with model: @task, url: "/tasks", method: :post, local:true do |f| %>
+
+  <div class="form-group">
+    <%= f.label :due, '期日' %>
+    <%= f.datetime_select :due, use_month_numbers: true, class: "form-control" %>
+  </div>
+  
+  <div class="form-group">
+    <%= f.label :title, 'タイトル' %>
+    <%= f.text_field :title %>
+  </div>
+  
+  <div class="form-group">
+    <%= f.label :detail, '詳細' %>
+    <%= f.text_area :detail %>
+  </div>
+  
+  <div class="form-group">
+    <%= f.label :priority_status, '優先度' %>
+    <%= f.select :priority_status, Task.priority_statuses.keys, {} %>
+  </div>
+  
+  <div class="actions">
+    <%= f.submit '作成する' %>
+  </div>
+<% end %>

--- a/app/views/public/tasks/show.html.erb
+++ b/app/views/public/tasks/show.html.erb
@@ -1,0 +1,17 @@
+<h1>リスト詳細画面</h1>
+
+<p>期日</p>
+<%= @task.due_jst %>
+<p>タイトル</p>
+<%= @task.title %>
+<p>詳細</p>
+<%= @task.detail %>
+<p>優先度</p>
+<%= @task.priority_status %>
+<p>進捗度</p>
+<%= form_with model: @task, url: "/tasks/#{@task.id}", method: :patch, local:true do |f| %>
+  <%= f.select :progress_status, Task.progress_statuses.keys, {} %>
+  <%= f.submit '更新' %>
+<% end %>
+
+<%= link_to '編集する', edit_task_path(@task.id) %>


### PR DESCRIPTION
## 関連URL
[f.datetime_selectドキュメント](https://railsdoc.com/page/datetime_select)
[strftimeライブラリ](https://docs.ruby-lang.org/ja/latest/method/Time/i/strftime.html)
[strftimeについて](https://techracho.bpsinc.jp/hachi8833/2016_10_06/25960)

## 概要（やったこと）
taskビュー（作成、一覧、詳細、編集）の骨組み
taskの作成、更新、削除処理

## やっていないこと
レイアウト調整
リスト作成画面：f.datetime_selectがutc & フォームのスタイル調整
リスト一覧画面：進捗度によって表示変える？、進捗以外も変更できるようにする？、リストないときは’なし’の表示
リスト編集画面：：f.datetime_selectがutc & フォームのスタイル調整、更新後のリダイレクト先

## 動作確認
動作問題なし

## UIに対する変更
なし

## その他
task_progressesコントローラー必要ない気がする