### PR TITLE
learningsテーブルのカラムを変更

### DIFF
--- a/db/migrate/20210102024707_remove_start_date_time_to_learning.rb
+++ b/db/migrate/20210102024707_remove_start_date_time_to_learning.rb
@@ -1,0 +1,5 @@
+class RemoveStartDateTimeToLearning < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :learnings, :start_date_time, :datetime
+  end
+end

--- a/db/migrate/20210102024832_remove_end_date_time_to_learning.rb
+++ b/db/migrate/20210102024832_remove_end_date_time_to_learning.rb
@@ -1,0 +1,5 @@
+class RemoveEndDateTimeToLearning < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :learnings, :end_date_time, :datetime
+  end
+end

--- a/db/migrate/20210102025200_add_date_to_learning.rb
+++ b/db/migrate/20210102025200_add_date_to_learning.rb
@@ -1,0 +1,5 @@
+class AddDateToLearning < ActiveRecord::Migration[5.2]
+  def change
+    add_column :learnings, :date, :date
+  end
+end

--- a/db/migrate/20210102025409_add_time_to_learning.rb
+++ b/db/migrate/20210102025409_add_time_to_learning.rb
@@ -1,0 +1,5 @@
+class AddTimeToLearning < ActiveRecord::Migration[5.2]
+  def change
+    add_column :learnings, :time, :float
+  end
+end

--- a/db/migrate/20210102025618_change_column_null_learning.rb
+++ b/db/migrate/20210102025618_change_column_null_learning.rb
@@ -1,0 +1,6 @@
+class ChangeColumnNullLearning < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :learnings, :date, false
+    change_column_null :learnings, :time, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_31_080023) do
+ActiveRecord::Schema.define(version: 2021_01_02_025618) do
+
+  create_table "admins", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_admins_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
+  end
 
   create_table "favorites", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -32,11 +44,11 @@ ActiveRecord::Schema.define(version: 2020_12_31_080023) do
     t.string "title", null: false
     t.string "image_id"
     t.text "detail"
-    t.datetime "start_date_time", null: false
-    t.datetime "end_date_time", null: false
     t.boolean "is_public", default: true, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.date "date", null: false
+    t.float "time", null: false
   end
 
   create_table "tasks", force: :cascade do |t|


### PR DESCRIPTION
## 関連URL
[マイグレーションファイルの削除](https://qiita.com/ISSO33/items/33a935cb3255c269bef2)

## 概要（やったこと）
learningsテーブルのカラムを変更した
・学習開始時間(start_date_time : datetime)、学習終了時間(end_date_time : datetime)を削除
・学習日(date : date)と学習時間(time : float)を追加

## やっていないこと
なし

## 動作確認
動作未確認

## UIに対する変更
なし

## その他
・当初は開始時間と終了時間を保存し、その差分から学習時間を算出しようと思った。
・ただ、学習内容を記録する画面で全ての情報を一度に入力しようと思っている。
・その場合、開始時間と終了時間を同時に入力することになり、開始と終了を用意する必要性を感じなくなった。
・そのため、差分ではなく、学習時間をそのまま保存し、+学習日を保存することにした。