### PR TITLE
新規登録とログイン画面のレイアウト

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -40,7 +40,7 @@ footer {
   border-radius: 30px;
 }
 .navbar-nav li a {
-  padding: 5px;
+  padding: 10px;
   color: #FFF;
   background-color: #808080;
   border-radius: 10px;
@@ -57,4 +57,31 @@ footer {
 }
 .copyright {
   line-height: 80px;
+}
+
+main {
+  background: #CBC5C1;
+}
+.card-header {
+  background: #3E3E3B;
+  padding-left: 80px;
+  font-size: 20px;
+  color: #FFF;
+}
+.card-body {
+  background: #EBECED;
+}
+
+// ボタン
+.btn {
+  color: #FFF;
+}
+.btn-outline-success {
+  background-color: #626E60;
+}
+.btn-outline-primary {
+  background-color: #494E6B;
+}
+.btn-outline-info {
+  background-color: #8EAEBD;
 }

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -7,10 +7,10 @@
           <div class="col-lg-12">
             <ul class="navbar-nav">
               <li><%= link_to 'マイページ', user_path(current_user) %></li>
-              <li><%= link_to 'MyStudy Noteとは', about_path %></li>
-              <li><%= link_to 'ユーザー一覧', users_path %></li>
-              <li><%= link_to '学習時間を確認', user_learning_times_path(current_user) %></li>
-              <li><%= link_to '学習時間を記録', new_learning_path %></li>
+              <li><%= link_to 'サイト説明', about_path %></li>
+              <li><%= link_to 'ユーザー', users_path %></li>
+              <li><%= link_to '学習時間確認', user_learning_times_path(current_user) %></li>
+              <li><%= link_to '学習時間記録', new_learning_path %></li>
               <li><%= link_to 'リスト作成', new_task_path %></li>
               <li><%= link_to 'ログアウト', destroy_user_session_path, method: :delete %></li>
             </ul>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,9 @@
 
   <body>
     <%= render 'layouts/header' %>
-    <%= yield %>
+    <main>
+      <%= yield %>
+    </main>
     <%= render 'layouts/footer' %>
   </body>
 </html>

--- a/app/views/public/registrations/new.html.erb
+++ b/app/views/public/registrations/new.html.erb
@@ -1,34 +1,46 @@
-<h2>新規登録</h2>
-
-<%= form_with model: @user, url: user_registration_path, local: true do |f| %>
-  <%= render "public/shared/error_messages", resource: resource %>
-  
-  <div class="field">
-    <%= f.label :nickname %><br />
-    <%= f.text_field :nickname, autofocus: true %>
+<div class="container">
+  <div class="row">
+    <div class="col-lg-8 offset-lg-2">
+      <div class="card mx-auto my-5">
+        <div class="card-header">新規登録</div>
+        <div class="card-body">
+          <%= form_with model: @user, url: user_registration_path, local: true do |f| %>
+          <%= render "public/shared/error_messages", resource: resource %>
+            <div class="row mt-3">
+              <div class="col-lg-10 offset-lg-1">
+                <%= f.label :nickname, 'ニックネーム（2〜10文字の範囲）', class: "col-lg-10 pl-0" %>
+                <%= f.text_field :nickname, autofocus: true, autocomplete: "nickname", class: "form-control" %>
+              </div>
+            </div>
+            <div class="row mt-3">
+              <div class="col-lg-10 offset-lg-1">
+                <%= f.label :email, 'メールアドレス' %>
+                <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control" %>
+              </div>
+            </div>
+            <div class="row mt-3">
+              <div class="col-lg-10 offset-lg-1">
+                <%= f.label :password, 'パスワード' %>
+                <% if @minimum_password_length %>
+                  <span>（<%= @minimum_password_length %>文字以上）</span>
+                <% end %>
+                <%= f.password_field :password, autocomplete: "new-password", class: "form-control" %>
+              </div>
+            </div>
+            <div class="row mt-3">
+              <div class="col-lg-10 offset-lg-1">
+                <%= f.label :password_confirmation, '確認用パスワード' %><br />
+                <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control" %>
+              </div>
+            </div>
+            <div class="row mt-4">
+              <div class="col-lg-10 offset-lg-1 text-center">
+                <%= f.submit "新規登録する", class: "btn btn-outline-success px-5" %>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
   </div>
-  
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password %>
-    <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
-    <% end %><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Sign up" %>
-  </div>
-<% end %>
-
-<%= render "public/shared/links" %>
+</div>

--- a/app/views/public/sessions/new.html.erb
+++ b/app/views/public/sessions/new.html.erb
@@ -1,27 +1,38 @@
-<h2>ログイン</h2>
-
-<%= form_with model: @user, url: user_session_path, local: true do |f| %>
-
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
-  </div>
-
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
+<div class="container">
+  <div class="row">
+    <div class="col-lg-8 offset-lg-2">
+      <div class="card mx-auto my-5">
+        <div class="card-header">ログイン</div>
+        <div class="card-body">
+          <%= form_with model: @user, url: user_session_path, local: true do |f| %>
+            <div class="row mt-3">
+              <div class="col-lg-10 offset-lg-1">
+                <%= f.label :nickname, 'ニックネーム', class: "col-lg-10 pl-0" %>
+                <%= f.text_field :nickname, autofocus: true, autocomplete: "nickname", class: "form-control" %>
+              </div>
+            </div>
+            <div class="row mt-3">
+              <div class="col-lg-10 offset-lg-1">
+                <%= f.label :password, 'パスワード' %>
+                <%= f.password_field :password, autocomplete: "current-password", class: "form-control" %>
+              </div>
+            </div>
+            <div class="row mt-4">
+              <div class="col-lg-10 offset-lg-1 text-center">
+                <%= f.submit "ログインする", class: "btn btn-outline-primary px-5" %>
+              </div>
+            </div>
+          <% end %>  
+        </div>
+      </div>
+      <div class="row mb-5">
+        <div class="col-lg-8 offset-lg-2 text-center">
+          <%= link_to 'ユーザー登録がお済みでない方はこちら', new_user_registration_path, class: "btn btn-outline-info px-5" %>
+        </div>
+      </div>
     </div>
-  <% end %>
-
-  <div class="actions">
-    <%= f.submit "Log in" %>
   </div>
-<% end %>
+</div>
 
-<%= render "public/shared/links" %>
+<!-- パスワード再設定(使用する場合はルーティングも変更する) -->
+<!--%= render "public/shared/links" %-->


### PR DESCRIPTION
## 関連URL
なし

## 概要（やったこと）
user側の新規登録画面とログイン画面のレイアウト

## やっていないこと
なし

## 動作確認
問題なし

## UIに対する変更
問題なし

## その他
ログイン後のヘッダが、画面を縮小するとナビゲーションリストの文字が二段になる
フッタの下に空白