### PR TITLE
#21

### DIFF
--- a/app/controllers/public/users_controller.rb
+++ b/app/controllers/public/users_controller.rb
@@ -1,5 +1,7 @@
 class Public::UsersController < ApplicationController
+  include Sidebarable
   before_action :ensure_correct_user, only: [:edit, :update]
+  before_action :set_sidebar, only: [:index, :show, :edit]
   
   def index
     @users = User.all

--- a/app/views/public/users/edit.html.erb
+++ b/app/views/public/users/edit.html.erb
@@ -1,28 +1,46 @@
-<h1>ユーザー編集画面</h1>
-
-<table>
-  <%= form_with model: @user, url: "/users/#{@user.id}", method: :patch, local:true do |f| %>
-    <tr>
-      <th><%= f.label :nickname, 'ニックネーム' %></th>
-      <td><%= f.text_field :nickname, autofocus: true %></td>
-    </tr>
-    <tr>
-      <th><%= f.label :biography, '自己紹介' %></th>
-      <td><%= f.text_area :biography %></td>
-    </tr>
-    <tr>
-      <th><%= f.label :image, 'プロフィール画像' %></th>
-      <td><%= f.attachment_field :image %>画像選択</td>
-    </tr>
-    <tr>
-      <th><%= f.label :email, 'メールアドレス' %></th>
-      <td><%= f.email_field :email %></td>
-    </tr>
-    <tr>
-      <td><%= f.submit '変更' %></td>
-    </tr>
-  <% end %>
-</table>
-
-<%=link_to '戻る', user_path(@user) %>
-
+<div class="container">
+  <div class="row">
+    <div class="col-lg-8">
+      <div class="card mx-auto my-5 shadow-lg">
+        <div class="card-header">ユーザー情報編集</div>
+        <div class="card-body">
+          <%= form_with model: @user, url: "/users/#{@user.id}", method: :patch, local:true do |f| %>
+            <div class="row mt-3">
+              <div class="col-lg-10 offset-lg-1">
+                <%= f.label :nickname, 'ニックネーム（2〜10文字の範囲）' %>
+                <%= f.text_field :nickname, autofocus: true, autocomplete: "nickname", class: "form-control" %>
+              </div>
+            </div>
+            <div class="row mt-3">
+              <div class="col-lg-10 offset-lg-1">
+                <%= f.label :biography, '自己紹介' %>
+                <%= f.text_area :biography, size: "20x10", class: "form-control" %>
+              </div>
+            </div>
+            <div class="row mt-3">
+              <div class="col-lg-10 offset-lg-1">
+                <%= f.label :image, 'プロフィール画像選択' %>
+                <%= f.attachment_field :image %>
+              </div>
+            </div>
+            <div class="row mt-3">
+              <div class="col-lg-10 offset-lg-1">
+                <%= f.label :email, 'メールアドレス' %>
+                <%= f.email_field :email, autocomplete: "email", class: "form-control" %>
+              </div>
+            </div>
+            <div class="row mt-4">
+              <div class="col-lg-10 offset-lg-1 text-center">
+                <%= f.submit '更新する', class: "btn btn-outline-primary px-5" %>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+    <div class="sidebar col-lg-4">
+      <%= render 'layouts/sidebar_top', today_study_time: @today_study_time, yesterday_study_time: @yesterday_study_time %>
+      <%= render 'layouts/sidebar_bottom', my_tasks: @my_tasks %>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## 関連URL
なし

## 概要（やったこと）
- public/users/editのレイアウト調整、
- ユーザー詳細=>ユーザー編集画面に遷移直後に編集ボタンが押せない(リロードすれば押せる)不具合解消

## やっていないこと
なし

## 動作確認
遷移直後に変更可能になった

## UIに対する変更

## その他
- 原因はform_with直下にtableを置いていたことだった(値の受け渡しができてるか確認したかっただけなので骨組みが適当過ぎた...反省します)
- 検証ツールで確認するとformが閉じた下にtableがあった
- リロードしたら押せた理由は不明
- 普通にレイアウトを調整すれば問題なかった