### PR TITLE
#42

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,3 +71,4 @@ gem 'pry-byebug'
 gem 'kaminari','~> 1.2.1'
 gem "chartkick"
 gem 'ransack'
+gem 'enum_help'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,8 @@ GEM
       warden (~> 1.2.3)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erubi (1.10.0)
     execjs (2.7.0)
     ffi (1.14.2)
@@ -323,6 +325,7 @@ DEPENDENCIES
   chromedriver-helper
   coffee-rails (~> 4.2)
   devise
+  enum_help
   font-awesome-sass (~> 5.13)
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -191,7 +191,8 @@ footer {
 }
 .header-sm,
 #task_chart,
-#learning_chart {
+#learning_chart,
+.list-none {
   background: #EBECED;
 }
 

--- a/app/models/concerns/enum_help_ransack.rb
+++ b/app/models/concerns/enum_help_ransack.rb
@@ -1,0 +1,10 @@
+module EnumHelpRansack
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def enums_i18n_ransack(enum_name)
+      enums = eval("self.#{enum_name.to_s.pluralize}")
+      enums.map { |k, v| [eval("self.#{enum_name.to_s.pluralize}_i18n")[k], v] }
+    end
+  end
+end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,8 +1,10 @@
 class Task < ApplicationRecord
+  include EnumHelpRansack
   belongs_to :user
   
   enum priority_status: { 高: 0, 中: 1, 低: 2 }
-  enum progress_status: { 未着手: 0, 処理中: 1, 完了: 2, 保留: 3 }
+  enum progress_status: { 未着手: 0, 処理中: 1, 完了済: 2, 保留中: 3 }
+  # enum progress_status: { not_started: 0, processing: 1, completed: 2, padding: 3 }
   
   validates :title, presence: true
   validates :due, presence: true

--- a/app/views/public/tasks/_index.html.erb
+++ b/app/views/public/tasks/_index.html.erb
@@ -17,9 +17,8 @@
 <% else %>
   <div class="row">
     <div class="col-lg-12">
-      <div class="m-3 p-3 text-center">
-        <h2>リストはありません</h2><br>
-        <p>リストを作成しましょう</p>
+      <div class="p-3 text-center list-none">
+        <h2>リストはありません</h2>
       </div>
     </div>
   </div>

--- a/app/views/public/tasks/_search_form.html.erb
+++ b/app/views/public/tasks/_search_form.html.erb
@@ -1,4 +1,8 @@
 <%= search_form_for search, url: search_tasks_path do |f| %>
-  <%= f.search_field :title_or_detail_cont, class: "search", placeholder: 'リストを検索' %>
+  <%= f.search_field :title_or_detail_cont, class: "search mr-3", placeholder: 'リストを検索' %>
+  <%= f.label :priority_status_eq, '優先度:' %>
+  <%= f.select :priority_status_eq, Task.priority_statuses.map{|k, v| [Task.priority_statuses_i18n[k], v]}, {include_blank: '選択なし'}, class: "py-2 mr-3" %>
+  <%= f.label :progress_status_eq, '進捗度:' %>
+  <%= f.select :progress_status_eq, Task.progress_statuses.map{|k, v| [Task.progress_statuses_i18n[k], v]}, {include_blank: '選択なし'}, class: "py-2 mr-3" %>
   <%= f.submit '検索', class: "search-btn p-1" %>
 <% end %>


### PR DESCRIPTION
## 関連URL
[enum_help_ransack](http://319ring.net/blog/archives/3041/)
[enum_help GitHub](https://github.com/zmbacker/enum_help)
[enum検索フォームの作成](https://qiita.com/e-yoshida/items/a1de4642354190a166d9)

## 概要（やったこと）
- enum_helpのインストール
- enum_help_ransackをtaskモデルにinclude
- 検索フォームをenum_help_ransack用に変更
- enumカラムは設定しないことも踏まえてinclude_blank追加

## やっていないこと
なし

## 動作確認
進捗度、優先度で検索できた

## UIに対する変更
なし

## その他
なし