### PR TITLE
#60

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -132,6 +132,9 @@
   font-size: 20px;
   color: #FFF;
 }
+.sign-btn div .btn {
+  width: 300px;
+}
 // 管理者ログイン
 .admin-header,
 .admin-title,
@@ -166,6 +169,9 @@
 }
 .btn-outline-danger {
   background-color: #CC0000;
+}
+.btn-outline-dark {
+  background-color: #999;
 }
 
 // leaning_times

--- a/app/controllers/public/mailer.rb
+++ b/app/controllers/public/mailer.rb
@@ -1,0 +1,2 @@
+class Public::Mailer < Devise::Mailer
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,6 +18,8 @@
     <div id="wrapper">
       <%= render 'layouts/header' %>
       <main>
+        <p class="notice"><%= notice %></p>
+        <p class="alert"><%= alert %></p>
         <%= yield %>
       </main>
       <%= render 'layouts/footer' %>

--- a/app/views/public/mailer/reset_password_instructions.html.erb
+++ b/app/views/public/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,8 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= @resource.nickname %>様</p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p>パスワードの変更は以下のリンクからお願いいたします。</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p><%= link_to 'パスワードを変更する', edit_password_url(@resource, reset_password_token: @token) %></p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p>リクエストしていない場合は、このメールを無視してください。</p>
+<p>上記のリンクにアクセスして新しいパスワードを作成するまで、パスワードは変更されません。</p>

--- a/app/views/public/passwords/edit.html.erb
+++ b/app/views/public/passwords/edit.html.erb
@@ -1,25 +1,45 @@
-<h2>Change your password</h2>
-
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "public/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
-
-  <div class="field">
-    <%= f.label :password, "New password" %><br />
-    <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
-    <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
+<div class="container">
+  <div class="row">
+    <div class="col-10 offset-1">
+      <div class="card mx-auto my-5 shadow-lg">
+        <div class="card-header sign-header"><i class="fas fa-key"></i> パスワード変更画面</div>
+        <div class="card-body">
+          <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+          <%= render "public/shared/error_messages", resource: resource %>
+            <%= f.hidden_field :reset_password_token %>
+            <div class="row mt-4">
+              <div class="col-10 offset-1">
+                <%= f.label :password, '新しいパスワード' %>
+                <% if @minimum_password_length %>
+                  <span>（<%= @minimum_password_length %>文字以上）</span>
+                <% end %>
+                <%= f.password_field :password, autofocus: true, autocomplete: "new-password", class: "form-control" %>
+              </div>
+            </div>
+            <div class="row mt-4">
+              <div class="col-10 offset-1">
+                <%= f.label :password_confirmation, '新しいパスワードの確認' %><br />
+                <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control" %>
+              </div>
+            </div>
+            <div class="row mt-5">
+              <div class="col-10 offset-1 text-center">
+                <%= f.submit "パスワードを変更する", class: "btn btn-outline-dark px-5" %>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      </div>
+      <div class="row mb-3 sign-btn">
+        <div class="col-8 offset-2 text-center">
+          <%= link_to 'ログインする', new_user_session_path, class: "btn btn-outline-primary px-5" %>
+        </div>
+      </div>
+      <div class="row mb-5 sign-btn">
+        <div class="col-8 offset-2 text-center">
+          <%= link_to '会員登録する', new_user_registration_path, class: "btn btn-outline-info px-5" %>
+        </div>
+      </div>
+    </div>
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Change my password" %>
-  </div>
-<% end %>
-
-<%= render "public/shared/links" %>
+</div>

--- a/app/views/public/passwords/new.html.erb
+++ b/app/views/public/passwords/new.html.erb
@@ -1,16 +1,35 @@
-<h2>Forgot your password?</h2>
-
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "public/shared/error_messages", resource: resource %>
-
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+<div class="container">
+  <div class="row">
+    <div class="col-10 offset-1">
+      <div class="card mx-auto my-5 shadow-lg">
+        <div class="card-header sign-header"><i class="fas fa-key"></i> パスワード再設定</div>
+        <div class="card-body">
+          <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+          <%= render "public/shared/error_messages", resource: resource %>
+            <div class="row mt-4">
+              <div class="col-10 offset-1">
+                <%= f.label :email, 'メールアドレス' %>
+                <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: '登録中のメールアドレスを入力してください', class: "form-control" %>
+              </div>
+            </div>
+            <div class="row mt-4">
+              <div class="col-10 offset-1 text-center">
+                <%= f.submit "送信する", class: "btn btn-outline-dark px-5" %>
+              </div>
+            </div>
+          <% end %>  
+        </div>
+      </div>
+      <div class="row mb-3 sign-btn">
+        <div class="col-8 offset-2 text-center">
+          <%= link_to 'ログインする', new_user_session_path, class: "btn btn-outline-primary px-5" %>
+        </div>
+      </div>
+      <div class="row mb-5 sign-btn">
+        <div class="col-8 offset-2 text-center">
+          <%= link_to '会員登録する', new_user_registration_path, class: "btn btn-outline-info px-5" %>
+        </div>
+      </div>
+    </div>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
-
-<%= render "public/shared/links" %>
+</div>

--- a/app/views/public/sessions/new.html.erb
+++ b/app/views/public/sessions/new.html.erb
@@ -31,9 +31,14 @@
           <% end %>  
         </div>
       </div>
-      <div class="row mb-5">
+      <div class="row mb-3 sign-btn">
         <div class="col-8 offset-2 text-center">
-          <%= link_to '会員登録がお済みでない方はこちら', new_user_registration_path, class: "btn btn-outline-info px-5" %>
+          <%= link_to '会員登録がお済みでない方はこちら', new_user_registration_path, class: "btn btn-outline-info" %>
+        </div>
+      </div>
+      <div class="row mb-5 sign-btn">
+        <div class="col-8 offset-2 text-center">
+          <%= link_to 'パスワードを忘れた方はこちら', new_user_password_path, class: "btn btn-outline-dark" %>
         </div>
       </div>
     </div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -60,4 +60,17 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    :enable_starttls_auto => true,
+    :address => "smtp.gmail.com",
+    :port => 587,
+    :domain => 'smtp.gmail.com',
+    :user_name => ENV['DEVISE_PASSWOAD_RESET_EMAIL'],
+    :password => ENV['DEVISE_PASSWOAD_RESET_PASSWOAD'],
+    :authentication => 'login'
+  }
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,10 +24,11 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = ENV['DEVISE_PASSWOAD_RESET_EMAIL']
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'
+  config.mailer = 'Public::Mailer'
 
   # Configure the parent class responsible to send e-mails.
   # config.parent_mailer = 'ActionMailer::Base'

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,7 @@
+ja:
+  devise:
+    mailer:
+      confirmation_instructions:
+        subject: 'アカウントの有効化のご案内'
+      reset_password_instructions:
+        subject: 'パスワード再設定のご案内'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   devise_for :users, controllers: {
     sessions: 'public/sessions',
     registrations: 'public/registrations',
+    passwords: 'public/passwords'
   }
   
   scope module: :public do


### PR DESCRIPTION
## 関連URL
[deviseでパスワードリセットメールの送り方](https://samoant.com/rails-app-wms-devise/)
[認証メールのテンプレートをカスタマイズ](http://yrfreelance.com/2019/01/13/rails-devise-mail-template/)
[devise GitHub](https://github.com/heartcombo/devise)

## 概要（やったこと）
 - deviseのパスワードリセット機能追加
 - パスワードリセットメールの内容編集
 - パスワード再設定画面のレイアウト（メール送信画面）
 - パスワード変更画面のレイアウト

## やっていないこと
 - ルーティングの変更（パスワード再設定画面でエラーメッセージを表示 => リロードでエラー発生、原因はURLがuser/passwordになり、user/showのidと勘違いされているから）

## 動作確認
 - メール送信確認
 - パスワードの変更を確認

## UIに対する変更

## その他
 - ローカル環境でパスワード変更画面にアクセスする際は、〜/users/password/edit?reset_password_tokenのusers手前の"〜"の部分をローカル環境のURLに変更すること。
