### PR TITLE
#66

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -203,11 +203,14 @@
   }
 }
 // 検索
+.admin-search-form,
 .search-form {
-  background: #EBECED;
-}
-.admin-search-form {
   width: 400px;
+}
+.search-button {
+  border-color : #00AA00;
+  background: #00CC00;
+  color: #FFF;
 }
 // タグ
 .tag {

--- a/app/assets/stylesheets/public/homes.scss
+++ b/app/assets/stylesheets/public/homes.scss
@@ -90,9 +90,8 @@
   }
 }
 .study-record-title {
-  background: linear-gradient(#512700, #B38355);
-  font-size: 20px;
-  color: #FFF;
+  color: #512700;
+  text-shadow: 0px 0px 20px #ffff00;
 }
 .study-record .card {
   max-width: 700px;

--- a/app/assets/stylesheets/public/learnings.scss
+++ b/app/assets/stylesheets/public/learnings.scss
@@ -9,7 +9,7 @@
   color: #FFF;
 }
 // public/learnings/show
-.learning-show-title {
+.learning-title {
   color: #512700;
   text-shadow: 0px 0px 20px #AAAA00;
 }

--- a/app/controllers/public/homes_controller.rb
+++ b/app/controllers/public/homes_controller.rb
@@ -1,9 +1,24 @@
 class Public::HomesController < ApplicationController
+  before_action :set_learning_search, only: [:common_learnings, :search]
   
   def top
-    @learnings = Learning.where(is_public: 1).page(params[:page]).reverse_order.per(5)
+    @learnings = Learning.where(is_public: 1).page(params[:page]).reverse_order.limit(5)
+  end
+  
+  def common_learnings
+    @learnings = Learning.where(is_public: 1).page(params[:page]).reverse_order.per(8)
     if params[:tag_name]
-      @learnings = Learning.tagged_with("#{params[:tag_name]}").page(params[:page]).reverse_order.per(5)
+      @learnings = Learning.tagged_with("#{params[:tag_name]}").page(params[:page]).reverse_order.per(8)
     end
+  end
+  
+  def search
+  end
+  
+  private
+  
+  def set_learning_search
+    @search = Learning.ransack(params[:q])
+    @learning_search = @search.result.page(params[:page]).reverse_order.per(8)
   end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -49,6 +49,11 @@
                   <i class="fas fa-users"></i> ユーザー一覧
                 <% end %>
               </li>
+              <li class="nav-item mr-4">
+                <%= link_to common_learnings_path, class: 'nav-link' do %>
+                  <i class="fas fa-book"></i> みんなの学習記録
+                <% end %>
+              </li>
               <li class="nav-item">
                 <%= link_to destroy_user_session_path, method: :delete, class: 'nav-link' do %>
                   <i class="fas fa-sign-out-alt"></i> ログアウト
@@ -76,6 +81,11 @@
               <li class="nav-item">
                 <%= link_to users_path, class: 'nav-link' do %>
                   <i class="fas fa-users"></i> ユーザー一覧
+                <% end %>
+              </li>
+              <li class="nav-item mr-4">
+                <%= link_to common_learnings_path, class: 'nav-link' do %>
+                  <i class="fas fa-book"></i> みんなの学習記録
                 <% end %>
               </li>
               <li class="nav-item">

--- a/app/views/public/homes/_search_form.html.erb
+++ b/app/views/public/homes/_search_form.html.erb
@@ -1,0 +1,6 @@
+<div class="search-field text-center my-2">
+  <%= search_form_for search, url: search_common_learnings_path do |f| %>
+    <%= f.search_field :user_nickname_or_title_or_detail_cont, class: "search-form p-1", placeholder: '投稿ユーザー名 or タイトル or 詳細で検索' %>
+    <%= f.submit '検索', class: "search-button p-1" %>
+  <% end %>
+</div>

--- a/app/views/public/homes/_study_record.html.erb
+++ b/app/views/public/homes/_study_record.html.erb
@@ -1,29 +1,23 @@
-<div class="card mx-5">
-  <div class="card-header text-center study-record-title">みんなの学習記録</div>
-  <div class="card-body">
-    <div class="container study-record">
-      <% learnings.each do |learning| %>
-        <div class="card mb-3 mx-auto">
-          <div class="row no-gutters p-2">
-            <div class="col-6">
-              <%= link_to learning_path(learning.id), class: "image-link-border" do %>
-                <%= attachment_image_tag learning, :image, format: "jpeg", fallback: "no_image.jpg" %>
-              <% end %>
-            </div>
-            <div class="col-6">
-              <div class="card-body">
-                <small class="card-text">学習日：<%= learning.date.strftime("%Y年%m月%d日") %></small>
-                <h4 class="card-title my-3 pb-1"><%= link_to learning.title, learning_path(learning.id) %></h4>
-                <p class="card-text my-2">学習時間：<i class="far fa-clock"></i><%= learning.time %>時間</p>
-                <small class="card-text my-3"><i class="far fa-comment"></i>コメント：<%= learning.learning_comments.count %>　<i class="far fa-heart"></i>いいね：<%= learning.favorites.count %></small><br>
-                <small class="card-text my-3"><%= learning.created_at.strftime("%Y年%m月%d日") %>投稿 by <%= link_to learning.user.nickname, user_path(learning.user) %></small><br>
-                <p class="card-text my-2">タグ：<%= render 'tag_list', tag_list: learning.tag_list %></p>
-              </div>
-            </div>
+<div class="container study-record">
+  <% learnings.each do |learning| %>
+    <div class="card mb-3 mx-auto">
+      <div class="row no-gutters p-2 bg-white">
+        <div class="col-6 d-flex align-items-center justify-content-center">
+          <%= link_to learning_path(learning.id), class: "image-link-border" do %>
+            <%= attachment_image_tag learning, :image, format: "jpeg", fallback: "no_image.jpg" %>
+          <% end %>
+        </div>
+        <div class="col-6">
+          <div class="card-body">
+            <small class="card-text">学習日：<%= learning.date.strftime("%Y年%m月%d日") %></small>
+            <h4 class="card-title my-3 pb-1"><%= link_to learning.title, learning_path(learning.id) %></h4>
+            <p class="card-text my-2">学習時間：<i class="far fa-clock"></i><%= learning.time %>時間</p>
+            <small class="card-text my-3"><i class="far fa-comment"></i>コメント：<%= learning.learning_comments.count %>　<i class="far fa-heart"></i>いいね：<%= learning.favorites.count %></small><br>
+            <small class="card-text my-3"><%= learning.created_at.strftime("%Y年%m月%d日") %>投稿 by <%= link_to learning.user.nickname, user_path(learning.user) %></small><br>
+            <p class="card-text my-2">タグ：<%= render 'tag_list', tag_list: learning.tag_list %></p>
           </div>
         </div>
-      <% end %>
+      </div>
     </div>
-    <%= paginate learnings %>
-  </div>
+  <% end %>
 </div>

--- a/app/views/public/homes/_tag_list.html.erb
+++ b/app/views/public/homes/_tag_list.html.erb
@@ -1,3 +1,3 @@
 <% tag_list.each do |tag| %>
-  <sapn><%= link_to tag, root_path(tag_name: tag), class: "tag p-1" %></sapn>
+  <sapn><%= link_to tag, common_learnings_path(tag_name: tag), class: "tag p-1" %></sapn>
 <% end %>

--- a/app/views/public/homes/common_learnings.html.erb
+++ b/app/views/public/homes/common_learnings.html.erb
@@ -1,0 +1,6 @@
+<div class="container study-record">
+  <h1 class="my-3 text-center study-record-title"><i class="fas fa-book"></i> みんなの学習記録</h1>
+  <%= render 'search_form', search: @search %>
+  <%= render 'study_record', learnings: @learnings %>
+  <%= paginate @learnings %>
+</div>

--- a/app/views/public/homes/search.html.erb
+++ b/app/views/public/homes/search.html.erb
@@ -1,0 +1,6 @@
+<div class="container study-record">
+  <h1 class="my-3 text-center study-record-title"><i class="fas fa-book"></i> みんなの学習記録検索結果</h1>
+  <%= render 'search_form', search: @search %>
+  <%= render 'study_record', learnings: @learning_search %>
+  <%= paginate @learning_search %>
+</div>

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -37,4 +37,8 @@
     </div>
   </div>
 </div>
-<%= render 'study_record', learnings: @learnings %>
+<div class="container study-record">
+  <h1 class="my-3 text-center study-record-title"><i class="fas fa-book"></i> みんなの学習記録</h1>
+  <%= render 'study_record', learnings: @learnings %>
+  <div class="text-center mb-5"><%= link_to 'もっと見る>>', common_learnings_path %></div>
+</div>

--- a/app/views/public/learnings/_index.html.erb
+++ b/app/views/public/learnings/_index.html.erb
@@ -1,26 +1,26 @@
-<table>
-  <thead>
-    <tr>
-      <th>学習日</th>
-      <th>画像</th>
-      <th>タイトル</th>
-      <th>学習時間</th>
-      <th>詳細</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% learnings.each do |learning| %>
-      <tr>
-        <td><%= learning.date %></td>
-        <td><%= attachment_image_tag learning, :image, format: "jpeg", fallback: "no_image.jpg" %></td>
-        <td><%= link_to learning.title, learning_path(learning.id) %></td>
-        <td><%= learning.time %>時間</td>
-        <td><%= learning.detail %></td>
-        <%= render 'tag_list', tag_list: learning.tag_list %>
-        <td><%= link_to '編集する', edit_learning_path(learning.id) %></td>
-        <td><%= link_to '削除する', learning_path(learning.id), method: :delete, "data-confirm" => "#{learning.title}をリストから削除しますか？" %></td>
-      </tr>
-    <% end %>
-  </tbody>
-  <%= paginate learnings %>
-</table>
+<% learnings.each do |learning| %>
+  <div class="card mb-3 mx-auto">
+    <div class="row no-gutters p-2 bg-white">
+      <div class="col-6 d-flex align-items-center justify-content-center">
+        <%= link_to learning_path(learning.id), class: "image-link-border" do %>
+          <%= attachment_image_tag learning, :image, format: "jpeg", fallback: "no_image.jpg" %>
+        <% end %>
+      </div>
+      <div class="col-6">
+        <div class="card-body p-2">
+          <small class="card-text">学習日：<%= learning.date.strftime("%Y年%m月%d日") %></small>
+          <h4 class="card-title my-2 pb-1"><%= link_to learning.title, learning_path(learning.id) %></h4>
+          <p class="card-text my-1">学習時間：<i class="far fa-clock"></i><%= learning.time %>時間</p>
+          <small class="card-text my-3"><i class="far fa-comment"></i>コメント：<%= learning.learning_comments.count %>　<i class="far fa-heart"></i>いいね：<%= learning.favorites.count %></small><br>
+          <small class="card-text my-3"><%= learning.created_at.strftime("%Y年%m月%d日") %>投稿</small><br>
+          <p class="card-text my-2">タグ：<%= render 'tag_list', tag_list: learning.tag_list %></p>
+          <% if learning.user = current_user %>
+            <%= link_to '編集する', edit_learning_path(learning.id), class: "btn btn-outline-info btn-sm m-2 edit-btn" %>
+            <%= link_to '削除する', learning_path(learning.id), method: :delete, "data-confirm" => "#{learning.title}をリストから削除しますか？", class: "btn btn-outline-danger btn-sm m-2 delete-btn" %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>
+<%= paginate learnings %>

--- a/app/views/public/learnings/_search_form.html.erb
+++ b/app/views/public/learnings/_search_form.html.erb
@@ -1,4 +1,6 @@
-<%= search_form_for search, url: search_learnings_path do |f| %>
-  <%= f.search_field :title_or_detail_cont, class: "search", placeholder: '学習記録を検索' %>
-  <%= f.submit '検索', class: "search-btn p-1" %>
-<% end %>
+<div class="search-field text-center my-2">
+  <%= search_form_for search, url: search_learnings_path do |f| %>
+    <%= f.search_field :title_or_detail_cont, class: "search-form p-1", placeholder: '学習記録を検索' %>
+    <%= f.submit '検索', class: "search-button p-1" %>
+  <% end %>
+</div>

--- a/app/views/public/learnings/index.html.erb
+++ b/app/views/public/learnings/index.html.erb
@@ -1,4 +1,5 @@
-<h1>自分の学習記録一覧</h1>
-
-<%= render 'index', learnings: @learnings %>
-<%= render 'search_form', search: @search %>
+<div class="container study-record">
+  <h1 class="my-3 text-center learning-title"><i class="fas fa-book-open"></i> <%= current_user.nickname %>さんの学習記録一覧</h1>
+  <%= render 'search_form', search: @search %>
+  <%= render 'index', learnings: @learnings %>
+</div>

--- a/app/views/public/learnings/search.html.erb
+++ b/app/views/public/learnings/search.html.erb
@@ -1,4 +1,5 @@
-<h1>自分の学習記録検索画面</h1>
-
-<%= render 'index', learnings: @learning_search %>
-<%= render 'search_form', search: @search %>
+<div class="container study-record">
+  <h1 class="my-3 text-center learning-title"><i class="fas fa-book-open"></i> <%= current_user.nickname %>さんの学習記録検索結果</h1>
+  <%= render 'search_form', search: @search %>
+  <%= render 'index', learnings: @learning_search %>
+</div>

--- a/app/views/public/learnings/show.html.erb
+++ b/app/views/public/learnings/show.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-  <h1 class="my-3 text-center learning-show-title"><i class="fa fa-book"></i> 学習記録詳細</h1>
+  <h1 class="my-3 text-center learning-title"><i class="fa fa-book"></i> 学習記録詳細</h1>
   <div class="row mx-0">
     <div class="col-4 text-center">
       <%= attachment_image_tag @learning, :image, format: "jpeg", fallback: "no_image.jpg", class: "w-100" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,8 @@ Rails.application.routes.draw do
   
   scope module: :public do
     root 'homes#top'
+    get 'common_learnings' => 'homes#common_learnings'
+    get 'common_learnings/search' => 'homes#search', as: :search_common_learnings
     resources :users, only: [:index, :show, :edit, :update] do
       get 'learning_times' => 'learning_times#index'
       get :search, on: :collection


### PR DESCRIPTION
## 関連URL
なし

## 概要（やったこと）
 - トップ画面の学習記録表示件数を5件に変更
 - homes#common_learningsを追加し、全てのユーザーの学習記録内容を表示
 - common_learnings用のタグ、検索フォーム、検索ページの作成
 - ユーザー側の(ログインユーザーの)学習内容一覧画面のレイアウト

## やっていないこと
 - 当初、マイページに学習内容を表示するつもりだったが、しないことにした

## 動作確認
動作確認OK

## UIに対する変更

## その他
