### PR TITLE
Add #71

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -60,6 +60,10 @@
   font-weight: 600;
   font-size: 18px;
 }
+.user-header-content .navbar-nav .nav-bottom a,
+.user-header-content .navbar-nav .nav-bottom h4 {
+  color: #156A15;
+}
 .header-main .navbar-toggler,
 .user-header-main .navbar-toggler,
 .user-header-content .navbar-toggler {
@@ -76,8 +80,9 @@
   border-bottom: solid 2px #CD853F;
   padding: 1rem;
   .navbar-nav .navbar-nav .nav-item a {
-    color: #512700;
+    color: #156A15;
     text-decoration: none;
+    font-size: 16px;
   }
 }
 // 管理者ヘッダー

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -102,6 +102,11 @@
                 <% end %>
               </li>
               <li class="nav-item nav-bottom">
+                <%= link_to user_learning_times_path(current_user), class: 'nav-link' do %>
+                  <i class="fas fa-user-clock"></i> 過去の学習時間
+                <% end %>
+              </li>
+              <li class="nav-item nav-bottom">
                 <%= link_to learnings_path, class: 'nav-link' do %>
                   <i class="fas fa-book-open"></i> 学習記録を確認
                 <% end %>
@@ -134,6 +139,11 @@
               <li class="nav-item nav-bottom mr-5">
                 <%= link_to user_path(current_user) do %>
                   <i class="fa fa-user"></i> マイページ
+                <% end %>
+              </li>
+              <li class="nav-item nav-bottom mr-5">
+                <%= link_to user_learning_times_path(current_user), class: 'nav-link' do %>
+                  <i class="fas fa-user-clock"></i> 過去の学習時間
                 <% end %>
               </li>
               <li class="nav-item nav-bottom mr-5">
@@ -175,6 +185,11 @@
             <li class="nav-item mr-4">
               <%= link_to root_path, class: 'nav-link' do %>
                 <i class="fas fa-home"></i> ホーム
+              <% end %>
+            </li>
+            <li class="nav-item mr-4">
+              <%= link_to common_learnings_path, class: 'nav-link' do %>
+                <i class="fas fa-book"></i> みんなの学習記録
               <% end %>
             </li>
             <li class="nav-item mr-4">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -93,27 +93,30 @@
                   <i class="fas fa-sign-out-alt"></i> ログアウト
                 <% end %>
               </li></br>
-              <li class="nav-item">
+              <li class="nav-item nav-bottom">
+                <h4><i class="fas fa-user-minus"></i> マイメニュー</h4>
+              </li>
+              <li class="nav-item nav-bottom">
                 <%= link_to user_path(current_user), class: 'nav-link' do %>
                   <i class="fa fa-user"></i> マイページ
                 <% end %>
               </li>
-              <li class="nav-item">
+              <li class="nav-item nav-bottom">
                 <%= link_to learnings_path, class: 'nav-link' do %>
                   <i class="fas fa-book-open"></i> 学習記録を確認
                 <% end %>
               </li>
-              <li class="nav-item">
+              <li class="nav-item nav-bottom">
                 <%= link_to tasks_path, class: 'nav-link' do %>
                   <i class="fa fa-list-alt"></i> ToDoリストを確認
                 <% end %>
               </li>
-              <li class="nav-item">
+              <li class="nav-item nav-bottom">
                 <%= link_to new_learning_path, class: 'nav-link' do %>
                   <i class="fa fa-edit"></i> 学習内容を記録
                 <% end %>
               </li>
-              <li class="nav-item">
+              <li class="nav-item nav-bottom">
                 <%= link_to new_task_path, class: 'nav-link' do %>
                   <i class="fa fa-plus-square"></i> ToDoリストを作成
                 <% end %>
@@ -128,27 +131,27 @@
         <div class="collapse navbar-collapse justify-content-center">
           <div class="navbar-nav">
             <ul class="navbar-nav align-items-center">
-              <li class="nav-item mr-5">
+              <li class="nav-item nav-bottom mr-5">
                 <%= link_to user_path(current_user) do %>
                   <i class="fa fa-user"></i> マイページ
                 <% end %>
               </li>
-              <li class="nav-item mr-5">
+              <li class="nav-item nav-bottom mr-5">
                 <%= link_to learnings_path do %>
                   <i class="fas fa-book-open"></i> 学習記録を確認
                 <% end %>
               </li>
-              <li class="nav-item mr-5">
+              <li class="nav-item nav-bottom mr-5">
                 <%= link_to tasks_path do %>
                   <i class="fa fa-list-alt"></i> ToDoリストを確認
                 <% end %>
               </li>
-              <li class="nav-item mr-5">
+              <li class="nav-item nav-bottom mr-5">
                 <%= link_to new_learning_path do %>
                   <i class="fa fa-edit"></i> 学習内容を記録
                 <% end %>
               </li>
-              <li class="nav-item">
+              <li class="nav-item nav-bottom">
                 <%= link_to new_task_path do %>
                   <i class="fa fa-plus-square"></i> ToDoリストを作成
                 <% end %>


### PR DESCRIPTION
## 関連URL
なし

## 概要（やったこと）
 - ログイン後のヘッダー下部（マイメニュー）のテキストカラーを変更
 - ログイン前のヘッダーに全ユーザーの学習内容一覧のリンクを追加
 - 過去の学習時間のリンクをヘッダーに追加（ログイン前・後）

## やっていないこと
 - ヘッダーにログインユーザーの画像とニックネームを表示する予定だったが、やらないことにした

## 動作確認
動作確認OK

## UIに対する変更

## その他
