### PR TITLE
#61

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -21,10 +21,27 @@
 //= require_tree .
 /*global $ */
 
-$(document).on('turbolinks:load', function() {
+// スライドショー
+$(document).on('turbolinks:load', function () {
   $('.slick-wrapper').slick({
     dots: true,
     autoplay: true,
     autoplaySpeed: 1200
+  });
+});
+
+// 画像プレビュー
+$(document).on('turbolinks:load', function () {
+  function readURL(input) {
+    if (input.files && input.files[0]) {
+      let reader = new FileReader();
+      reader.onload = function (e) {
+        $('.image-preview').attr('src', e.target.result);
+      };
+      reader.readAsDataURL(input.files[0]);
+    }
+  }
+  $('.image-field').change(function () {
+    readURL(this);
   });
 });

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -300,3 +300,17 @@
     background-color: #FF6633;
   }
 }
+// 画像プレビュー
+.learning-image {
+  width: 250px;
+}
+.user-image {
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+}
+.image-preview:hover {
+  cursor: pointer; 
+  opacity: 0.7;
+  transform: scale(1.01, 1.01);
+}

--- a/app/views/admins/learnings/_tag_list.html.erb
+++ b/app/views/admins/learnings/_tag_list.html.erb
@@ -1,3 +1,3 @@
 <% tag_list.each do |tag| %>
-  <sapn><%= link_to tag, admins_learnings_path(tag_name: tag), class: "admin-learning-tag px-1" %></sapn>
+  <sapn><%= link_to tag, admins_learnings_path(tag_name: tag), class: "admin-learning-tag p-1" %></sapn>
 <% end %>

--- a/app/views/admins/learnings/edit.html.erb
+++ b/app/views/admins/learnings/edit.html.erb
@@ -34,8 +34,9 @@
             </div>
             <div class="row mt-4">
               <div class="col-10 offset-1">
-                <%= f.label :image, '画像選択' %><br>
-                <%= f.attachment_field :image %>
+                <%= f.label :image, '画像を選択してください' %><br>
+                <%= f.file_field :image, class: "image-field", style: "display:none;" %>
+                <%= attachment_image_tag @learning, :image, format: "jpeg", fallback: "no_image.jpg", onClick: "$('.image-field').click()", class: "learning-image img-thumbnail img-responsive center-block image-preview" %>
               </div>
             </div>
             <div class="row mt-4">

--- a/app/views/admins/users/edit.html.erb
+++ b/app/views/admins/users/edit.html.erb
@@ -20,8 +20,9 @@
             </div>
             <div class="row mt-4">
               <div class="col-10 offset-1">
-                <%= f.label :image, 'プロフィール画像選択' %>
-                <%= f.attachment_field :image %>
+                <%= f.label :image, 'プロフィール画像選択' %><br>
+                <%= f.file_field :image, class: "image-field", style: "display:none;" %>
+                <%= attachment_image_tag @user, :image, format: "jpeg", fallback: "user-no-img-min.jpg", onClick: "$('.image-field').click()", class: "user-image img-thumbnail img-responsive center-block image-preview" %>
               </div>
             </div>
             <div class="row mt-4">

--- a/app/views/public/homes/_tag_list.html.erb
+++ b/app/views/public/homes/_tag_list.html.erb
@@ -1,3 +1,3 @@
 <% tag_list.each do |tag| %>
-  <sapn><%= link_to tag, common_learnings_path(tag_name: tag), class: "tag learning-tag px-1" %></sapn>
+  <sapn><%= link_to tag, common_learnings_path(tag_name: tag), class: "tag learning-tag p-1" %></sapn>
 <% end %>

--- a/app/views/public/learnings/_tag_list.html.erb
+++ b/app/views/public/learnings/_tag_list.html.erb
@@ -1,3 +1,3 @@
 <% tag_list.each do |tag| %>
-  <sapn><%= link_to tag, learnings_path(tag_name: tag), class: "tag learning-tag px-1" %></sapn>
+  <sapn><%= link_to tag, learnings_path(tag_name: tag), class: "tag learning-tag p-1" %></sapn>
 <% end %>

--- a/app/views/public/learnings/edit.html.erb
+++ b/app/views/public/learnings/edit.html.erb
@@ -34,8 +34,9 @@
             </div>
             <div class="row mt-4">
               <div class="col-10 offset-1">
-                <%= f.label :image, '画像選択' %><br>
-                <%= f.attachment_field :image %>
+                <%= f.label :image, '画像を選択してください' %><br>
+                <%= f.file_field :image, class: "image-field", style: "display:none;" %>
+                <%= attachment_image_tag @learning, :image, format: "jpeg", fallback: "no_image.jpg", onClick: "$('.image-field').click()", class: "learning-image img-thumbnail img-responsive center-block image-preview" %>
               </div>
             </div>
             <div class="row mt-4">

--- a/app/views/public/learnings/new.html.erb
+++ b/app/views/public/learnings/new.html.erb
@@ -34,8 +34,9 @@
             </div>
             <div class="row mt-4">
               <div class="col-10 offset-1">
-                <%= f.label :image, '画像選択' %><br>
-                <%= f.attachment_field :image %>
+                <%= f.label :image, '画像を選択してください' %><br>
+                <%= f.file_field :image, class: "image-field", style: "display:none;" %>
+                <%= attachment_image_tag @learning, :image, format: "jpeg", fallback: "no_image.jpg", onClick: "$('.image-field').click()", class: "learning-image img-thumbnail img-responsive center-block image-preview" %>
               </div>
             </div>
             <div class="row mt-4">

--- a/app/views/public/tasks/_tag_list.html.erb
+++ b/app/views/public/tasks/_tag_list.html.erb
@@ -1,3 +1,3 @@
 <% tag_list.each do |tag| %>
-  <sapn><%= link_to tag, tasks_path(tag_name: tag), class: "tag task-tag px-1" %></sapn>
+  <sapn><%= link_to tag, tasks_path(tag_name: tag), class: "tag task-tag p-1" %></sapn>
 <% end %>

--- a/app/views/public/users/edit.html.erb
+++ b/app/views/public/users/edit.html.erb
@@ -20,8 +20,9 @@
             </div>
             <div class="row mt-4">
               <div class="col-10 offset-1">
-                <%= f.label :image, 'プロフィール画像選択' %>
-                <%= f.attachment_field :image %>
+                <%= f.label :image, 'プロフィール画像選択' %><br>
+                <%= f.file_field :image, class: "image-field", style: "display:none;" %>
+                <%= attachment_image_tag @user, :image, format: "jpeg", fallback: "user-no-img-min.jpg", onClick: "$('.image-field').click()", class: "user-image img-thumbnail img-responsive center-block image-preview" %>
               </div>
             </div>
             <div class="row mt-4">


### PR DESCRIPTION
## 関連URL
[Web アプリケーションからのファイルの使用<=これの「例: ユーザが選択した画像のサムネイルを表示」を参考](https://developer.mozilla.org/ja/docs/Web/API/File/Using_files_from_web_applications)
[new演算子](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Operators/new)
[onload](https://techacademy.jp/magazine/15558)
[input type=”file”の話<=これのfiles[0]と配列の指定](https://www.cresco.co.jp/blog/entry/710/)
[readUrl](https://docs.mulesoft.com/jp/mule-runtime/4.2/dw-core-functions-readurl)
[画像プレビュー](https://qiita.com/matsubishi5/items/34276fce924aded4061a)

## 概要（やったこと）
 - 画像プレビュー機能の追加
 - ユーザー側の学習記録作成/編集画面とユーザー編集画面に追加
 - 管理者側の学習記録編集画面とユーザー編集画面に追加

## やっていないこと
なし

## 動作確認
動作確認OK

## UIに対する変更

## その他
