### PR TITLE
config/environments/production 'config.force_ssl = true' uncomment

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
## 関連URL

## 概要（やったこと）
 - config/environments/productionの50行目 'config.force_ssl = true' のコメントアウトをはずした（CertbotのHTTPS設定を解除し、IPアドレスでHTTP接続できることを確認したため）

## やっていないこと

## 動作確認

## UIに対する変更

## その他
