### PR TITLE
Fix #162

### DIFF
--- a/app/controllers/public/learnings_controller.rb
+++ b/app/controllers/public/learnings_controller.rb
@@ -8,7 +8,7 @@ class Public::LearningsController < ApplicationController
   end
 
   def index
-    @learnings = current_user.learnings.page(params[:page]).sorted(8)
+    @learnings = current_user.learnings.includes(:tags).page(params[:page]).sorted(8)
     if params[:tag_name]
       @learnings = current_user.learnings.tagged_with("#{params[:tag_name]}").page(params[:page]).sorted(8)
     end

--- a/app/controllers/public/tasks_controller.rb
+++ b/app/controllers/public/tasks_controller.rb
@@ -36,7 +36,7 @@ class Public::TasksController < ApplicationController
   def task_params
     params.require(:task).permit(:title, :detail, :priority_status, :due, :progress_status, :tag_list)
   end
-  
+
   def set_new_task
     @task = Task.new
   end
@@ -49,14 +49,14 @@ class Public::TasksController < ApplicationController
   end
 
   def set_task_search
-    @search = current_user.tasks.ransack(params[:q])
+    @search = current_user.tasks.includes(:tags).ransack(params[:q])
     @task_search = @search.result.page(params[:page]).sorted(10)
   end
 
   def set_task_index
-    @tasks = current_user.tasks.page(params[:page]).sorted(10)
+    @tasks = current_user.tasks.includes(:tags).page(params[:page]).sorted(10)
     if params[:tag_name]
-      @tasks = current_user.tasks.tagged_with("#{params[:tag_name]}").page(params[:page]).sorted(10)
+      @tasks = current_user.tasks.includes(:tags).tagged_with("#{params[:tag_name]}").page(params[:page]).sorted(10)
     end
   end
 end

--- a/app/views/public/learnings/_index.html.erb
+++ b/app/views/public/learnings/_index.html.erb
@@ -1,4 +1,4 @@
-<% learnings.includes(:taggings).each do |learning| %>
+<% learnings.each do |learning| %>
   <div class="card mb-3 mx-auto">
     <div class="row no-gutters p-2 bg-white">
       <div class="col-lg-6 d-flex align-items-center justify-content-center">
@@ -13,7 +13,7 @@
           <p class="card-text my-1">学習時間：<i class="far fa-clock"></i><%= learning.time %>時間</p>
           <small class="card-text my-3"><i class="far fa-comment"></i>コメント：<%= learning.learning_comments.count %>　<i class="far fa-heart"></i>いいね：<%= learning.favorites.count %></small><br>
           <small class="card-text my-3"><%= learning.created_at.strftime("%Y年%m月%d日") %>投稿</small><br>
-          <p class="card-text my-2">タグ：<%= render 'tag_list', tag_list: learning.tag_list %></p>
+          <p class="card-text my-2">タグ：<%= render 'tag_list', tags: learning.tags %></p>
           <% if learning.user = current_user %>
             <%= link_to '編集する', edit_learning_path(learning.id), class: "btn btn-outline-info btn-sm m-2 edit-btn" %>
             <%= link_to '削除する', learning_path(learning.id), method: :delete, "data-confirm" => "#{learning.title}をリストから削除しますか？", class: "btn btn-outline-danger btn-sm m-2 delete-btn" %>

--- a/app/views/public/learnings/_tag_list.html.erb
+++ b/app/views/public/learnings/_tag_list.html.erb
@@ -1,3 +1,3 @@
-<% tag_list.each do |tag| %>
+<% tags.each do |tag| %>
   <sapn><%= link_to tag, learnings_path(tag_name: tag), class: "tag learning-tag p-1" %></sapn>
 <% end %>

--- a/app/views/public/tasks/_edit.html.erb
+++ b/app/views/public/tasks/_edit.html.erb
@@ -46,7 +46,7 @@
       </th>
     </tr>
     <tr>
-      <td><%= f.text_field :tag_list, value: task.tag_list.join(','), class: "form-control", placeholder: '例：プログラミング,ruby,rails' %></td>
+      <td><%= f.text_field :tag_list, value: task.tags.pluck(:name).join(','), class: "form-control", placeholder: '例：プログラミング,ruby,rails' %></td>
     </tr>
     <tr>
       <th><%= f.label :priority_status, 'タスクの優先度', class: "mt-3" %></th>

--- a/app/views/public/tasks/_index.html.erb
+++ b/app/views/public/tasks/_index.html.erb
@@ -1,5 +1,5 @@
 <div class="row">
-  <% tasks.includes(:taggings).each.with_index(1) do |task, index| %>
+  <% tasks.each.with_index(1) do |task, index| %>
     <div class="col-lg-8 offset-lg-2">
       <div class="card-body m-2 task-content <%= add_class_name_progress(task.progress_status) + '-content' %>">
         <small class="<%= "text-danger" if task.due < Time.now %> card-text">
@@ -26,7 +26,7 @@
         <%= link_to task_path(task.id), method: :delete, "data-confirm" => "#{task.title}をリストから削除しますか？", remote: true  do %>
           <i class="far fa-trash-alt" title="削除する"></i>
         <% end %><br>
-        <small class="card-text">タグ：<%= render 'tag_list', tag_list: task.tag_list %></small>
+        <small class="card-text">タグ：<%= render 'tag_list', tags: task.tags %></small>
       </div>
     </div>
   <% end %>

--- a/app/views/public/tasks/_new.html.erb
+++ b/app/views/public/tasks/_new.html.erb
@@ -46,7 +46,7 @@
       </th>
     </tr>
     <tr>
-      <td><%= f.text_field :tag_list, value: task.tag_list.join(','), class: "form-control", placeholder: '例：プログラミング,ruby,rails' %></td>
+      <td><%= f.text_field :tag_list, value: task.tags.pluck(:name).join(','), class: "form-control", placeholder: '例：プログラミング,ruby,rails' %></td>
     </tr>
     <tr>
       <th><%= f.label :priority_status, 'タスクの優先度', class: "mt-3" %></th>

--- a/app/views/public/tasks/_tag_list.html.erb
+++ b/app/views/public/tasks/_tag_list.html.erb
@@ -1,3 +1,3 @@
-<% tag_list.each do |tag| %>
-  <sapn><%= link_to tag, tasks_path(tag_name: tag), class: "tag task-tag p-1" %></sapn>
+<% tags.each do |tag| %>
+  <sapn><%= link_to tag.name, tasks_path(tag_name: tag.name), class: "tag task-tag p-1" %></sapn>
 <% end %>

--- a/app/views/public/tasks/show.html.erb
+++ b/app/views/public/tasks/show.html.erb
@@ -28,7 +28,7 @@
           </tr>
           <tr>
             <th>タグ</th>
-            <td colspan="2"><%= render 'public/tasks/tag_list', tag_list: @task.tag_list %></td>
+            <td colspan="2"><%= render 'public/tasks/tag_list', tags: @task.tags %></td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
## 関連URL
[RubyonRails:acts-as-taggable-onのN+1問題を解決する](https://madogiwa0124.hatenablog.com/entry/2018/04/22/185625)

## 概要（やったこと）
 - public/learning#indexのタグのN+1問題
 - taskのタグのN+1問題対策

## やっていないこと
 - controllerでincludesしているがviewのeachしているところでincludesしたほうがいいかも（記述量は少なくなる、クエリの発行回数は確認していない）
 - learningはindexしかしていないし、他の部分は確認していないのでエラーでるかも

## 動作確認
 - タスクは確認済み（タグの発行回数減った、ビューの表示OK、タスク検索・タグ検索OK、作成・編集・削除処理問題なし）

## UIに対する変更

## その他
色々ややこしかったのでメモ
 - 取得する際はtaggingsじゃなくてtagsでincludesしてキャッシュ
 - タグ名表示はtagsで（tag_listは使わない）
 - newとeditでタグ名を表示するときはtags.pluck(:name).join(',')で（pulckでタグの名前一覧を取得してjoin(',')）
 - indexでタグの名前を表示するときはtag(tags).nameで（eachで回してるので）