### PR TITLE
public/learning#show 画像の表示方法修正

### DIFF
--- a/app/models/learning.rb
+++ b/app/models/learning.rb
@@ -105,5 +105,13 @@ class Learning < ApplicationRecord
       end
       dates
     end
+
+    def image_url
+      if Rails.env.production?
+        "https://#{ENV['AWS_S3_BUCKET_NAME']}.s3-ap-northeast-1.amazonaws.com/store/" + self.image_id
+      else
+        Refile.attachment_url(self, :image)
+      end
+    end
   end
 end

--- a/app/views/public/learnings/show.html.erb
+++ b/app/views/public/learnings/show.html.erb
@@ -4,7 +4,11 @@
   <h1 class="my-3 text-center learning-title"><i class="fa fa-book"></i> 学習記録詳細</h1>
   <div class="row mx-0 bg-light mb-3 p-2 rounded">
     <div class="col-lg-4 d-flex align-items-center justify-content-center">
-      <%= attachment_image_tag @learning, :image, format: "jpeg", fallback: "no_image.jpg", class: "learning-image img-responsive center-block" %>
+      <% if @image_url.nil? %>
+        <%= image_tag "no_image.jpg", class: "learning-image img-responsive center-block" %>
+      <% else %>
+        <%= image_tag @learning.image_url, class: "learning-image img-responsive center-block" %>
+      <% end %>
     </div>
     <div class="col-lg-8">
       <table class="table show-table">


### PR DESCRIPTION
## 関連URL
[Refileのurl取得](https://qiita.com/hitochan/items/fd3877c44eeac8f66309)

## 概要（やったこと）
 - ユーザー側の学習記録詳細画面の画像表示方法変更
 - 本番環境 -> S3のbucketを指定
 - 開発環境 -> attachment_urlを指定

## やっていないこと
- 他の箇所は未修正

## 動作確認
- 開発環境は確認済み
- 本番環境は未確認

## UIに対する変更

## その他
とりあえず学習記録詳細画面のみ修正