### PR TITLE
ユーザー側の学習記録詳細画面にユーザーのプロフィール画像を追加

### DIFF
--- a/app/assets/stylesheets/public/learnings.scss
+++ b/app/assets/stylesheets/public/learnings.scss
@@ -33,6 +33,11 @@
     font-size: 14px;
     text-decoration: none;
   }
+  .user-profile-resize {
+    height: 35px;
+    width: 35px;
+    border-radius: 50%;
+  }
   .user-name a {
     text-decoration: none;
     color: #512700;

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,6 +30,14 @@ class User < ApplicationRecord
     followings.include?(user)
   end
 
+  def image_url
+    if self.image_id?
+      "https://mystudynote-img-files-resize.s3-ap-northeast-1.amazonaws.com/store/#{self.image_id}-thumbnail."
+    else
+      'https://mystudynote-img-files-resize.s3-ap-northeast-1.amazonaws.com/store/user-no-img.png'
+    end
+  end
+
   def self.index_page(page)
     page(page).per(8)
   end

--- a/app/views/public/learnings/show.html.erb
+++ b/app/views/public/learnings/show.html.erb
@@ -37,7 +37,12 @@
           </tr>
           <tr class="user-info">
             <th>ユーザー</th>
-            <td colspan="2" class="user-name"><%= link_to @learning.user.nickname, user_path(@learning.user) %></td>
+            <td colspan="2" class="user-name">
+              <%= link_to user_path(@learning.user) do %>
+                <%= image_tag @learning.user.image_url, class: "user-profile-resize" %>
+                <%= @learning.user.nickname %>
+              <% end %>
+            </td>
           </tr>
           <tr>
             <td colspan="2">


### PR DESCRIPTION
## 関連URL

## 概要（やったこと）
 - ユーザー側の学習記録詳細画面にユーザーのプロフィール画像を追加
 - lambda + S3 でresizeしたユーザープロフィール画像を表示

## やっていないこと

## 動作確認
 - ローカルでは表示されている

## UIに対する変更

## その他
