### PR TITLE
#213 ユーザー/管理者の新規登録とログイン画面のテストシナリオ修正

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -35,6 +35,7 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   config.include UserSignInModule
+  config.include AdminSignInModule
   config.include LearningNewModule
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::IntegrationHelpers, type: :request

--- a/spec/support/admin_sign_in_module.rb
+++ b/spec/support/admin_sign_in_module.rb
@@ -1,0 +1,8 @@
+module AdminSignInModule
+  def admin_sign_in_as(admin)
+    visit new_admin_session_path
+    fill_in "メールアドレス", with: admin.email
+    fill_in "パスワード", with: admin.password
+    click_button "ログインする"
+  end
+end

--- a/spec/system/admins/sessions_spec.rb
+++ b/spec/system/admins/sessions_spec.rb
@@ -1,37 +1,47 @@
 require "rails_helper"
 
-RSpec.describe "adminログインとログアウト", type: :system do
+RSpec.describe "admin/sessions", type: :system do
   let(:admin) { create(:admin) }
 
-  context "ログインできる場合" do
-    it "正確なパラメータを入力したらログインでき、管理者側ユーザー一覧画面に遷移する。その後、ログアウトして管理者ログイン画面に遷移する。" do
-      visit admin_session_path
-      fill_in "メールアドレス", with: admin.email
-      fill_in "パスワード", with: admin.password
-      click_button "ログインする"
-      aggregate_failures do
-        expect(current_path).to eq "/admins/users"
-        expect(page).to have_content "ログインしました。"
+  describe "管理者ログイン" do
+    context "成功する場合" do
+      it "内容を入力し、'ログインする'ボタンを選択すると管理者ユーザー一覧画面に遷移する。" do
+        visit admin_session_path
+        fill_in "メールアドレス", with: admin.email
+        fill_in "パスワード", with: admin.password
+        click_button "ログインする"
+        aggregate_failures do
+          expect(current_path).to eq "/admins/users"
+          expect(page).to have_content "ログインしました。"
+        end
       end
+    end
 
+    context "失敗する場合" do
+      it "内容を入力し、'ログインする'ボタンを選択するとエラーメッセージが表示される。" do
+        visit admin_session_path
+        fill_in "メールアドレス", with: admin.email
+        fill_in "パスワード", with: "111111"
+        click_button "ログインする"
+        aggregate_failures do
+          expect(current_path).to eq "/admins/sign_in"
+          expect(page).to have_content "メールアドレスまたはパスワードが違います。"
+        end
+      end
+    end
+  end
+
+  describe "管理者ログアウト" do
+    before do
+      admin_sign_in_as(admin)
+    end
+
+    it "ログアウトしたら管理者ログイン画面に遷移する。" do
       find(".logout-link").click
       aggregate_failures do
         expect(current_path).to eq "/admins/sign_in"
         expect(page).to have_link "ログイン"
         expect(page).to have_content "ログアウトしました。"
-      end
-    end
-  end
-
-  context "ログインできない場合" do
-    it "不正なパラメータを入力したらログインできない。その後、再度管理者ログイン画面へ。" do
-      visit admin_session_path
-      fill_in "メールアドレス", with: admin.email
-      fill_in "パスワード", with: "111111"
-      click_button "ログインする"
-      aggregate_failures do
-        expect(current_path).to eq "/admins/sign_in"
-        expect(page).to have_content "メールアドレスまたはパスワードが違います。"
       end
     end
   end

--- a/spec/system/public/registrations_spec.rb
+++ b/spec/system/public/registrations_spec.rb
@@ -1,41 +1,43 @@
 require "rails_helper"
 
-RSpec.describe "user新規登録", type: :system do
-  context "新規登録できる場合" do
-    it "正確なパラメータを入力したら新規登録が出来る。その後、トップ画面に遷移する。" do
-      user = build(:user)
-      visit root_path
-      click_link "会員登録"
-      fill_in "ニックネーム(2〜10文字)", with: user.nickname
-      fill_in "メールアドレス", with: user.email
-      fill_in "パスワード", with: user.password
-      fill_in "確認用パスワード", with: user.password_confirmation
-      aggregate_failures do
-        expect do
-        click_button "新規登録する"
-        end.to change(User, :count).by(1)
-        expect(current_path).to eq "/"
-        expect(page).to have_content "アカウント登録が完了しました"
+RSpec.describe "registrations", type: :system do
+  describe "ユーザー新規登録" do
+    context "新規登録できる場合" do
+      it "内容を入力し、'新規登録する'ボタンを選択するとトップ画面に遷移する。" do
+        user = build(:user)
+        visit root_path
+        click_link "会員登録"
+        fill_in "ニックネーム(2〜10文字)", with: user.nickname
+        fill_in "メールアドレス", with: user.email
+        fill_in "パスワード", with: user.password
+        fill_in "確認用パスワード", with: user.password_confirmation
+        aggregate_failures do
+          expect do
+          click_button "新規登録する"
+          end.to change(User, :count).by(1)
+          expect(current_path).to eq "/"
+          expect(page).to have_content "アカウント登録が完了しました"
+        end
       end
     end
-  end
 
-  context "新規登録できない場合" do
-    it "不正なパラメータを入力したら新規登録できない。その後、再度新規登録画面へ。" do
-      user = build(:user)
-      visit root_path
-      click_link "会員登録"
-      fill_in "ニックネーム(2〜10文字)", with: "あ"
-      fill_in "メールアドレス", with: user.email
-      fill_in "パスワード", with: user.password
-      fill_in "確認用パスワード", with: user.password_confirmation
-      aggregate_failures do
-        expect do
-        click_button "新規登録する"
-        end.to change(User, :count).by(0)
-        expect(current_path).to eq "/sign_up"
-        expect(page).to have_content "エラーが発生したため ユーザ は保存されませんでした。"
-        expect(page).to have_content "ニックネームは2文字以上で入力してください"
+    context "新規登録できない場合" do
+      it "内容を入力し、'新規登録する'ボタンを選択するとエラーメッセージが表示される。" do
+        user = build(:user)
+        visit root_path
+        click_link "会員登録"
+        fill_in "ニックネーム(2〜10文字)", with: "あ"
+        fill_in "メールアドレス", with: user.email
+        fill_in "パスワード", with: user.password
+        fill_in "確認用パスワード", with: user.password_confirmation
+        aggregate_failures do
+          expect do
+          click_button "新規登録する"
+          end.to change(User, :count).by(0)
+          expect(current_path).to eq "/sign_up"
+          expect(page).to have_content "エラーが発生したため ユーザ は保存されませんでした。"
+          expect(page).to have_content "ニックネームは2文字以上で入力してください"
+        end
       end
     end
   end

--- a/spec/system/public/sessions_spec.rb
+++ b/spec/system/public/sessions_spec.rb
@@ -1,39 +1,49 @@
 require "rails_helper"
 
-RSpec.describe "userログインとログアウト", type: :system do
+RSpec.describe "sessions", type: :system do
   let(:user) { create(:user) }
 
-  context "ログインできる場合" do
-    it "正確なパラメータを入力したらログインでき、トップ画面に遷移する。その後、ログアウトする。" do
-      visit root_path
-      click_link "ログイン"
-      fill_in "メールアドレス", with: user.email
-      fill_in "パスワード", with: user.password
-      click_button "ログインする"
-      aggregate_failures do
-        expect(current_path).to eq "/"
-        expect(page).to have_content "ログインしました。"
+  describe "ログインする" do
+    context "成功する場合" do
+      it "内容を入力し、'ログインする'ボタンを選択するとトップ画面に遷移する。" do
+        visit root_path
+        click_link "ログイン"
+        fill_in "メールアドレス", with: user.email
+        fill_in "パスワード", with: user.password
+        click_button "ログインする"
+        aggregate_failures do
+          expect(current_path).to eq "/"
+          expect(page).to have_content "ログインしました。"
+        end
       end
+    end
 
+    context "失敗する場合" do
+      it "内容を入力し、'ログインする'ボタンを選択するとエラーメッセージが表示される。" do
+        visit root_path
+        click_link "ログイン"
+        fill_in "メールアドレス", with: user.email
+        fill_in "パスワード", with: "111111"
+        click_button "ログインする"
+        aggregate_failures do
+          expect(current_path).to eq "/sign_in"
+          expect(page).to have_content "メールアドレスまたはパスワードが違います。"
+        end
+      end
+    end
+  end
+
+  describe "ログアウトする" do
+    before do
+      sign_in_as(user)
+    end
+
+    it "ログアウトしたらトップ画面に遷移する。" do
       find(".logout-link").click
       aggregate_failures do
         expect(current_path).to eq "/"
         expect(page).to have_link "ログイン"
         expect(page).to have_content "ログアウトしました。"
-      end
-    end
-  end
-
-  context "ログインできない場合" do
-    it "不正なパラメータを入力したらログインできない。その後、再度ログイン画面へ。" do
-      visit root_path
-      click_link "ログイン"
-      fill_in "メールアドレス", with: user.email
-      fill_in "パスワード", with: "111111"
-      click_button "ログインする"
-      aggregate_failures do
-        expect(current_path).to eq "/sign_in"
-        expect(page).to have_content "メールアドレスまたはパスワードが違います。"
       end
     end
   end


### PR DESCRIPTION
## 関連URL

## 概要（やったこと）
- ユーザー&管理者の新規登録とログインテストのシナリオ文を修正

## やっていないこと

## 動作確認
- テストOK

## UIに対する変更

## その他
